### PR TITLE
add svg to mime type extensions

### DIFF
--- a/src/Eloquent/Image.php
+++ b/src/Eloquent/Image.php
@@ -39,7 +39,7 @@ class Image implements JsonSerializable
         'image/gif' => 'gif',
         'image/webp' => 'webp',
         'image/bmp' => 'bmp',
-        'image/svg+xml' => 'svg+xml',
+        'image/svg+xml' => 'svg',
     ];
 
     public ?Filesystem $filesystem = null;

--- a/src/Eloquent/Image.php
+++ b/src/Eloquent/Image.php
@@ -39,6 +39,7 @@ class Image implements JsonSerializable
         'image/gif' => 'gif',
         'image/webp' => 'webp',
         'image/bmp' => 'bmp',
+        'image/svg+xml' => 'svg+xml',
     ];
 
     public ?Filesystem $filesystem = null;


### PR DESCRIPTION
Required for [VOY-2693](https://ziffmedia.atlassian.net/browse/VOY-2693)

Per [MDN docs](https://developer.mozilla.org/en-US/docs/Web/Media/Guides/Formats/Image_types#svg_scalable_vector_graphics), MIME type is `image/svg+xml` and file extension is `.svg`

